### PR TITLE
Improve cross‑platform installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # XJObsidian
 
-XJObsidian is a tool that makes note-taking with xournal++ and Obsidian easier.
+XJObsidian is a tool that makes note-taking with xournal++ and Obsidian easier. The project ships with a portable installation script that works on Linux, macOS and Windows (via WSL).
 
 ## Table of Contents
 - [Roadmap](#roadmap)
@@ -24,8 +24,9 @@ View project's [Roadmap](./ROADMAP.md) and don't be shy to propose your changes 
 ### Prerequisites
 - Git
 - Bash
+- `xournalpp` and `inotifywait`
 
-### Steps
+### Steps (Linux, macOS or WSL)
 1. Clone the repository:
 ```sh
 git clone https://github.com/AstyCX/xjobsidian.git
@@ -39,6 +40,11 @@ cd xjobsidian
 chmod +x install.sh
 ./install.sh
 ```
+   - On **macOS** you may need Homebrew for dependencies:
+     ```sh
+     brew install xournalpp inotify-tools
+     ```
+   - On **Windows**, run the script inside a [WSL](https://learn.microsoft.com/windows/wsl/about) environment with the same prerequisites installed.
 4. Setting up the configuration
 - Provide absolute path to your **Vault**, **Xournal++ template** (that would be used by default to create new notes) and **path to a folder** inside of your Vault where you want to save new notes
 - Path **must** be in a format of $HOME/...

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,4 +15,6 @@
 
 - [ ] Migrate to Python
 
+- [ ] Improve installation script for cross-platform support (Linux, macOS, WSL)
+
 - [ ] **YOUR PROPOSITIONS**

--- a/install.sh
+++ b/install.sh
@@ -1,21 +1,49 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
+
+# Detect operating system for package installation
+OS="$(uname -s)"
+
+# Detect if running under Windows Subsystem for Linux
+if grep -qi microsoft /proc/version 2>/dev/null; then
+    OS="WSL"
+fi
+
+install_cmd() {
+    case "$OS" in
+        Linux*|WSL*)
+            sudo apt update && sudo apt install -y "$1"
+            ;;
+        Darwin*)
+            if ! command -v brew &>/dev/null; then
+                echo "Homebrew is required to install $1. Please install Homebrew first: https://brew.sh" >&2
+                return 1
+            fi
+            brew install "$1"
+            ;;
+        *)
+            echo "Please install $1 manually for your platform." >&2
+            return 1
+            ;;
+    esac
+}
 
 # Check if required commands are available
 for cmd in xournalpp inotifywait; do
-    if ! command -v "$cmd" &> /dev/null; then
+    if ! command -v "$cmd" >/dev/null 2>&1; then
         read -p "Error: $cmd is not installed. Install it automatically? (y/n): " choice
         case "$choice" in
             y|Y )
-                sudo apt update
-                sudo apt install "$cmd"
-                sudo apt upgrade
+                install_cmd "$cmd" || {
+                    echo "$cmd is required. Exiting." >&2
+                    exit 1
+                }
                 ;;
             n|N )
-                echo "$cmd is required. Exiting."
+                echo "$cmd is required. Exiting." >&2
                 exit 1
                 ;;
             * )
-                echo "Invalid option. Please enter 'y' or 'n'."
+                echo "Invalid option. Please enter 'y' or 'n'." >&2
                 exit 1
                 ;;
         esac
@@ -51,7 +79,6 @@ fi
 notes_path="$notes_input"
 
 cat <<EOL > ~/.xjobsidian_config
-# ~/.xjobsidian_configcat <<EOL > ~/.xjobsidian_config
 # ~/.xjobsidian_config
 
 # Path to the Obsidian Vault

--- a/usr/local/bin/xjobsidian.sh
+++ b/usr/local/bin/xjobsidian.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 if [ -f ~/.xjobsidian_config ]; then
     source ~/.xjobsidian_config
@@ -6,6 +6,11 @@ else
     echo "Error: Configuration file ~/.xjobsidian_config not found. Please run the installation script first."
     exit 1
 fi
+
+# Determine the correct command for opening files
+OS="$(uname -s)"
+open_cmd="xdg-open"
+[ "$OS" = "Darwin" ] && open_cmd="open"
 
 # Use the `vault_path` and `template_path` variables from the config file
 obsidian="$vault_path"
@@ -89,7 +94,7 @@ encoded_lesson=$(echo "$lesson" | sed 's/ /%20/g')
 encoded_topic=$(echo "$unique_topic" | sed 's/ /%20/g')
 
 # Use the Obsidian URI to open the markdown file
-xdg-open "obsidian://open?vault=$vault_name&file=School%20Notes/$encoded_lesson/$encoded_topic.md"
+$open_cmd "obsidian://open?vault=$vault_name&file=School%20Notes/$encoded_lesson/$encoded_topic.md"
 
 # Monitor the .xopp file for modifications and update the PDF
 while true; do


### PR DESCRIPTION
## Summary
- update README with cross-platform installation instructions
- detect Linux/macOS/WSL in `install.sh`
- install dependencies with apt or brew
- fix config output
- adjust xjobsidian script to use OS-specific open command
- note upcoming cross-platform support in roadmap

## Testing
- `bash -n install.sh`
- `bash -n usr/local/bin/xjobsidian.sh`
